### PR TITLE
Removed documentation for --checkdeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Run `quickscrape --help` from the command line to get help:
     -o, --output <path>     where to output results (directory will be created if it doesn't exist
     -r, --ratelimit <int>   maximum number of scrapes per minute (default 3)
     -l, --loglevel <level>  amount of information to log (silent, verbose, info*, data, warn, error, or debug)
-    --checkdeps             check if dependencies are installed and then exit
 
 ```
 


### PR DESCRIPTION
This option was removed in bd287e0bfe30aa2bd7a18ad1ba01f7b4cb62f1a6.  Updating README to reflect this.

Although I note an option to check dependencies would be useful for the wrapper.
