### PR TITLE
Fix url list processing

### DIFF
--- a/bin/quickscrape.js
+++ b/bin/quickscrape.js
@@ -187,9 +187,6 @@ var checkForNext = function() {
     if (next < urllist.length) {
       lasttime = new Date().getTime();
       processUrl(urllist[next]);
-      if (next == urllist.length - 1) {
-        finish();
-      }
     } else {
       finish();
     }


### PR DESCRIPTION
When specifying a list of urls to process, through the `urllist` file param, the last url is not processed.

I believe its a race condition, whereas `finish()` is called on a `setTimeout()` tick, without the last url having finished processing.

I removed an `finish` call as it will be called on the ensuing ticks.