### PR TITLE
Added simple implementation of code to skip URLs already processed

### DIFF
--- a/bin/quickscrape.js
+++ b/bin/quickscrape.js
@@ -43,6 +43,8 @@ program
           'JSON format to transform results into (currently only bibjson)')
   .option('-f, --logfile <filename>',
           'save log to specified file in output directory as well as printing to terminal')
+  .option('-k, --skipexisting',
+          'skip previously processed URLs (that is, if the URL output folder exists)')
   .parse(process.argv);
 
 if (!process.argv.slice(2).length) {
@@ -221,6 +223,21 @@ var processUrl = function(url) {
   if (!fs.existsSync(dir)) {
     log.debug('creating output directory: ' + dir);
     fs.mkdirSync(dir);
+    if (program.skipexisting) {
+        // We need to reset this to get proper rate limiting
+        // now that we have a URL we actually need to download
+        mintime = 60000 / program.ratelimit;
+    }
+  }
+  else {
+    if (program.skipexisting) {
+      log.debug('Skipping as output directory already exists');
+      done = true;
+      // No need to do rate limiting this time as we haven't
+      // downloaded anything!
+      mintime = 0;
+      return;
+    }
   }
   process.chdir(dir);
 


### PR DESCRIPTION
This is a simple implementation of a feature to skip URLs that have already been processed (Issue #70). It is relatively naive, but should be useful.

It adds a new command-line option (`-k` or `--skipexisting`) which, if enabled, means that quickscrape checks to see if the output folder it is going to use for a URL already exists, and if so then skips that URL. It will also skip the rate-limiting at that point (as we don't need to rate-limit if we haven't actually downloaded any URLs), and reinstate the rate-limiting next time it actually downloads a URL.

This is my first PR written in javascript, so I may have done some completely stupid things! Feedback would be greatly appreciated.