### PR TITLE
sanitize creation of folder

### DIFF
--- a/bin/quickscrape.js
+++ b/bin/quickscrape.js
@@ -11,7 +11,8 @@ var program = require('commander')
   , Scraper = thresher.Scraper
   , ep = require('../lib/eventparse.js')
   , loglevels = require('../lib/loglevels.js')
-  , outformat = require('../lib/outformat.js');
+  , outformat = require('../lib/outformat.js')
+  , sanitize = require('sanitize-filename');
 
 
 var pjson = require('../package.json');
@@ -223,7 +224,7 @@ var processUrl = function(url) {
 
   // url-specific output dir
   var dir = program.numberdirs ? ('' + i) : url.replace(/\/+/g, '_').replace(/:/g, '');
-  dir = path.join(tld, dir);
+  dir = sanitize(path.join(tld, dir));
   if (!fs.existsSync(dir)) {
     log.debug('creating output directory: ' + dir);
     fs.mkdirSync(dir);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "moment": "~2.10.2",
     "thresher": "^0.1.11",
     "which": "~1.0.5",
-    "winston": "~1.0.0"
+    "winston": "~1.0.0",
+    "sanitize-filename": "1.6.0"
   },
   "bin": {
     "quickscrape": "bin/quickscrape.js"


### PR DESCRIPTION
Fixes #85. Uses npm module to santize filenames which are too long or contain odd characters.